### PR TITLE
Add job modal to Job Tracker

### DIFF
--- a/.idea/.idea.JobAppRazorWeb/.idea/dataSources.xml
+++ b/.idea/.idea.JobAppRazorWeb/.idea/dataSources.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="jobs.sqlite" uuid="4acc840b-69c4-49ca-862d-b8508042ebbd">
+      <driver-ref>sqlite.xerial</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
+      <jdbc-url>jdbc:sqlite:T:/NextCloud/OneDrive/Scripts/Python/JobChecker/jobs.sqlite</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/Models/AddJobDto.cs
+++ b/Models/AddJobDto.cs
@@ -1,0 +1,9 @@
+namespace JobAppRazorWeb.Models;
+
+public class AddJobDto
+{
+    public string JobBoard { get; set; } = string.Empty;
+    public string Company { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string ApplyUrl { get; set; } = string.Empty;
+}

--- a/Pages/JobTracker.cshtml
+++ b/Pages/JobTracker.cshtml
@@ -33,7 +33,8 @@
         <div>
             <span
                 id="new-jobs-today-count">🆕 Jobs Found Today: @Model.JobTracker.NewJobCount ℹ️ Available to apply: @Model.JobTracker.NewJobAvailableCount</span>
-            <span id="applied-today-count">🗓️ Applied Today: @Model.JobTracker.AppliedTodayCount</span>
+            <span id="applied-today-count" class="me-2">🗓️ Applied Today: @Model.JobTracker.AppliedTodayCount</span>
+            <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#addJobModal">Add Job</button>
         </div>
     </div>
     <br/>
@@ -106,6 +107,39 @@
     pointer-events: none;
 ">
         Copied to clipboard!
+    </div>
+    <!-- Add Job Modal -->
+    <div class="modal fade" id="addJobModal" tabindex="-1" aria-labelledby="addJobLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="addJobLabel">Add Job</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="jobBoardInput" class="form-label">Job Board</label>
+                        <input type="text" class="form-control" id="jobBoardInput">
+                    </div>
+                    <div class="mb-3">
+                        <label for="companyInput" class="form-label">Company Name</label>
+                        <input type="text" class="form-control" id="companyInput">
+                    </div>
+                    <div class="mb-3">
+                        <label for="titleInput" class="form-label">Job Title</label>
+                        <input type="text" class="form-control" id="titleInput">
+                    </div>
+                    <div class="mb-3">
+                        <label for="urlInput" class="form-label">URL</label>
+                        <input type="text" class="form-control" id="urlInput">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="submitAddJob">Submit</button>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 </body>
@@ -221,6 +255,37 @@
         url.searchParams.set('jobId', result);
         window.location.href = url.toString();
     }
+
+    document.getElementById('submitAddJob').addEventListener('click', async () => {
+        const payload = {
+            jobBoard: document.getElementById('jobBoardInput').value,
+            company: document.getElementById('companyInput').value,
+            title: document.getElementById('titleInput').value,
+            applyUrl: document.getElementById('urlInput').value
+        };
+
+        const response = await fetch('?handler=AddJob', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'RequestVerificationToken': document.querySelector('input[name="__RequestVerificationToken"]').value
+            },
+            body: JSON.stringify(payload)
+        });
+
+        if (!response.ok) {
+            console.error('Failed to add job', await response.text());
+            return;
+        }
+
+        const modal = bootstrap.Modal.getInstance(document.getElementById('addJobModal'));
+        modal.hide();
+
+        const result = await response.json();
+        const url = new URL(window.location.href);
+        url.searchParams.set('jobId', result);
+        window.location.href = url.toString();
+    });
 </script>
 
 </html>

--- a/Pages/JobTracker.cshtml
+++ b/Pages/JobTracker.cshtml
@@ -226,7 +226,7 @@
         
         if (action === 'applied') {
             payload.applied = "YES";
-            payload.appliedOn = new Date().toISOString();
+            payload.appliedOn = new Date().toISOString().split('.')[0] + 'Z';
         }
         if (action === 'duplicate') {
             payload.applied = "DUPE"

--- a/Pages/JobTracker.cshtml.cs
+++ b/Pages/JobTracker.cshtml.cs
@@ -59,6 +59,16 @@ public class JobsModel(IDaBase daBase) : PageModel
         }
         return new JsonResult(updatedJob.JobId);
     }
+
+    public async Task<IActionResult> OnPostAddJobAsync([FromBody] AddJobDto newJob)
+    {
+        var addedJob = await daBase.AddJobAsync(newJob);
+        if (addedJob == null)
+        {
+            return BadRequest();
+        }
+        return new JsonResult(addedJob.JobId);
+    }
     
     private bool UrlMatch(string url)
     {

--- a/Services/DaBase.cs
+++ b/Services/DaBase.cs
@@ -1,5 +1,7 @@
 using System.Data.SQLite;
 using JobAppRazorWeb.Models;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace JobAppRazorWeb.Services;
 
@@ -69,6 +71,76 @@ public class DaBase : IDaBase
         }
 
         return null;
+    }
+
+    public async Task<JobViewModel?> AddJobAsync(AddJobDto newJob)
+    {
+        var jobId = HashUrl(newJob.ApplyUrl);
+        var now = DateTime.UtcNow;
+
+        await using var conn = new SQLiteConnection(_connectionString);
+        await conn.OpenAsync().ConfigureAwait(false);
+
+        string insertJob = @"
+            INSERT INTO jobs (job_id, job_board, company, title, apply_url, first_seen, last_seen)
+            VALUES (@job_id, @job_board, @company, @title, @apply_url, @now, @now);";
+
+        await using (var jobCmd = new SQLiteCommand(insertJob, conn))
+        {
+            jobCmd.Parameters.AddWithValue("@job_id", jobId);
+            jobCmd.Parameters.AddWithValue("@job_board", newJob.JobBoard);
+            jobCmd.Parameters.AddWithValue("@company", newJob.Company);
+            jobCmd.Parameters.AddWithValue("@title", newJob.Title);
+            jobCmd.Parameters.AddWithValue("@apply_url", newJob.ApplyUrl);
+            jobCmd.Parameters.AddWithValue("@now", now);
+            await jobCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        string insertApp = @"
+            INSERT INTO applications (job_id, applied, applied_on)
+            VALUES (@job_id, 'YES', @now);";
+
+        await using (var appCmd = new SQLiteCommand(insertApp, conn))
+        {
+            appCmd.Parameters.AddWithValue("@job_id", jobId);
+            appCmd.Parameters.AddWithValue("@now", now);
+            await appCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        string selectQuery = @"
+            SELECT j.job_id, j.job_board, j.company, j.title, j.apply_url, j.first_seen, j.last_seen, a.applied, a.applied_on
+            FROM jobs j
+            LEFT JOIN applications a ON j.job_id = a.job_id
+            WHERE j.job_id = @job_id;";
+
+        await using var selectCmd = new SQLiteCommand(selectQuery, conn);
+        selectCmd.Parameters.AddWithValue("@job_id", jobId);
+
+        await using var reader = await selectCmd.ExecuteReaderAsync().ConfigureAwait(false);
+        if (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            return new JobViewModel
+            {
+                JobId = reader.GetString(0),
+                JobBoard = reader.GetString(1),
+                Company = reader.GetString(2),
+                Title = reader.GetString(3),
+                ApplyUrl = reader.GetString(4),
+                FirstSeen = reader.GetDateTime(5),
+                LastSeen = reader.GetDateTime(6),
+                Applied = reader.IsDBNull(7) ? null : reader.GetString(7),
+                AppliedOn = reader.IsDBNull(8) ? null : reader.GetDateTime(8)
+            };
+        }
+
+        return null;
+    }
+
+    private static string HashUrl(string url)
+    {
+        using var md5 = MD5.Create();
+        var bytes = md5.ComputeHash(Encoding.UTF8.GetBytes(url));
+        return BitConverter.ToString(bytes).Replace("-", string.Empty).ToLowerInvariant();
     }
 
     private async Task<List<JobViewModel>> QueryJobsAsync(string sqlQuery)

--- a/Services/IDaBase.cs
+++ b/Services/IDaBase.cs
@@ -6,4 +6,5 @@ public interface IDaBase
 {
     public Task<List<JobViewModel>> GetJobsAsync();
     public Task<JobViewModel?> UpdateApplicationAsync(ModifyApplicationDto appliedJob);
+    public Task<JobViewModel?> AddJobAsync(AddJobDto newJob);
 }


### PR DESCRIPTION
## Summary
- support creating new jobs through AddJobDto and DB service method
- extend IDaBase with AddJobAsync
- add handler on job tracker page to submit new jobs
- implement modal in JobTracker.cshtml with button to open it
- compute jobId from URL hash and mark as applied immediately

## Testing
- `dotnet restore`

------
https://chatgpt.com/codex/tasks/task_e_6859d230295c8324b7f001bd5e153c15