### PR TITLE
feat: Add readonly DB_PATH environment variable in Unraid JobApp.xml …

### DIFF
--- a/JobApp.xml
+++ b/JobApp.xml
@@ -24,4 +24,9 @@ Recommended: keep under /mnt/user/appdata/ for easy backup."
     <Config Name="Database File" Target="/data/jobs.sqlite" Default="/mnt/user/external_dbs/jobapp/jobs.sqlite" Mode="rw"
             Description="Full path to the SQLite database file stored on Unraid. "
             Type="Path" Display="always" Required="true" Mask="false">/mnt/user/external_dbs/jobapp/jobs.sqlite</Config>
+
+    <!-- Readonly env var for the app (kept in Advanced) -->
+    <Config Name="DB_PATH" Target="DB_PATH" Default="/data/jobs.sqlite" Mode=""
+            Description="Environment variable used by the app. Matches the container path of the selected DB file."
+            Type="Variable" Display="advanced" Required="true" Mask="false" Readonly="true">/data/jobs.sqlite</Config>
 </Container>


### PR DESCRIPTION
…template

- Matches the container path of the selected SQLite DB file
- Helps in maintaining consistent app configuration

@codex