### PR TITLE
fix: restore config fallback for database connection

### DIFF
--- a/Services/DaBase.cs
+++ b/Services/DaBase.cs
@@ -12,12 +12,21 @@ public class DaBase : IDaBase
     public DaBase(IConfiguration config)
     {
         var dbPath = Environment.GetEnvironmentVariable("DB_PATH");
-        
-        if (string.IsNullOrWhiteSpace(dbPath))
-            throw new InvalidOperationException("DB_PATH Not Found");
-        
-        _connectionString = $"Data Source ={dbPath}"
-                            ?? throw new InvalidOperationException("Connection String Not Found");
+        string? connectionString = null;
+
+        if (!string.IsNullOrWhiteSpace(dbPath))
+        {
+            connectionString = $"Data Source={dbPath}";
+        }
+
+        connectionString ??= config.GetConnectionString("DefaultConnection");
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException("Connection string not found. Set DB_PATH or ConnectionStrings:DefaultConnection.");
+        }
+
+        _connectionString = connectionString;
     }
 
     public async Task<List<JobViewModel>> GetJobsAsync()


### PR DESCRIPTION
## Summary
- allow DaBase to build a connection string from DB_PATH when supplied
- fall back to the existing ConnectionStrings:DefaultConnection configuration when DB_PATH is absent
- ensure application still fails fast only when neither source is configured

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68f979b3aeb08324bcd09b368cd247db